### PR TITLE
Resolve #92

### DIFF
--- a/src/learn/learner.cpp
+++ b/src/learn/learner.cpp
@@ -84,6 +84,7 @@
 
 #if defined(EVAL_NNUE)
 #include "../nnue/evaluate_nnue_learner.h"
+#include <climits>
 #include <shared_mutex>
 #endif
 


### PR DESCRIPTION
If we're defining something in a header then we should declare it.